### PR TITLE
내 정보 페이지 기초 마크업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import "./styles/App.scss";
 import { Route } from "react-router-dom";
 import MainPage from "./pages/MainPage";
+import MyInfo from "./pages/MyInfo";
 
 function App() {
   return (
     <div className="App">
       <Route path="/" component={MainPage} />
+      <Route path="/MyInfo" component={MyInfo} />
     </div>
   );
 }

--- a/src/components/MyInfo/FirstTab.tsx
+++ b/src/components/MyInfo/FirstTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+const FirstTab = () => {
+  return (
+    <div className="FirstTab">
+      <p>css는 추후에... 탭 기능만 구현한 페이지입니다.</p>
+      {/* First tab content will go here */}
+    </div>
+  );
+};
+export default FirstTab;

--- a/src/components/MyInfo/MyInfoHeader.tsx
+++ b/src/components/MyInfo/MyInfoHeader.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "../../pages/MyInfo.scss";
+import MyInfoHeaderDisplay from "./MyInfoHeaderDisplay";
+
+const MyInfoHeader = () => {
+  return (
+    <div className="MyInfoHeader">
+      <div className="Top">
+        <button className="GoBackButton">뒤로가기</button>
+        <div className="MyInfoTitle"> 내 정보 </div>
+      </div>
+      <MyInfoHeaderDisplay />
+    </div>
+  );
+};
+
+export default MyInfoHeader;

--- a/src/components/MyInfo/MyInfoHeaderDisplay.tsx
+++ b/src/components/MyInfo/MyInfoHeaderDisplay.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import "../../pages/MyInfo.scss";
+
+const MyInfoHeaderDisplay = () => {
+  return (
+    <div className="MyInfoHeaderDisplay">
+      <div>이름이랑 아이콘, 칭호 들어갈 곳</div>
+      <button className="LogoutButton">로그아웃</button>
+    </div>
+  );
+};
+
+export default MyInfoHeaderDisplay;

--- a/src/components/MyInfo/MyInfoTabs.tsx
+++ b/src/components/MyInfo/MyInfoTabs.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useState } from "react";
+import "../../pages/MyInfo.scss";
+import FirstTab from "./FirstTab";
+import SecondTab from "./SecondTab";
+import ThirdTab from "./ThirdTab";
+
+const MyInfoTabs = () => {
+
+  // 탭 이름들
+  const TabOneName: string = "통계";
+  const TabTwoName: string = "캐릭터 선택";
+  const TabThreeName: string = "칭호";
+
+  // 어떤 탭이 보여질지.
+  const [activeTab, setActiveTab] = useState(TabOneName);
+
+  // useCallback 하면 작동안함.
+  const WhichTabComponent = () => {
+    if (activeTab === TabOneName) {
+      return <FirstTab />
+    }
+    if (activeTab === TabTwoName) {
+      return <SecondTab /> 
+    }
+    if (activeTab === TabThreeName) {
+      return <ThirdTab />
+    }
+  }
+
+  //  Functions to handle Tab Switching
+  const handleTab = useCallback( (TabName: string) => {
+    setActiveTab(TabName);
+  }, []);
+
+
+  return (
+    <div className="MyInfoTabs">
+      <ul className="TabNav">
+        <li 
+          className={activeTab === TabOneName ? "active" : ""}
+          onClick={() => handleTab(TabOneName)}
+        >{TabOneName}</li>
+        <li 
+          className={activeTab === TabTwoName ? "active" : ""}
+          onClick={() => handleTab(TabTwoName)}
+        >{TabTwoName}</li>
+        <li 
+          className={activeTab === TabThreeName ? "active" : ""}
+          onClick={() => handleTab(TabThreeName)}
+        >{TabThreeName}</li>
+      </ul>
+      <div className="TabOutlet">
+        {WhichTabComponent()}
+      </div>
+    </div>
+  );
+};
+
+export default MyInfoTabs;

--- a/src/components/MyInfo/SecondTab.tsx
+++ b/src/components/MyInfo/SecondTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+const SecondTab = () => {
+  return (
+    <div className="SecondTab">
+      <p>Second Tab!! Hurray!!</p>
+      {/* Second  tab content will go here */}
+    </div>
+  );
+};
+export default SecondTab;

--- a/src/components/MyInfo/ThirdTab.tsx
+++ b/src/components/MyInfo/ThirdTab.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+const ThirdTab = () => {
+  return (
+    <div className="ThirdTab">
+      <p>Third Tab!! Hurray!!</p>
+      {/* Thrid tab content will go here */}
+    </div>
+  );
+};
+export default ThirdTab;

--- a/src/pages/MyInfo.scss
+++ b/src/pages/MyInfo.scss
@@ -1,0 +1,139 @@
+@mixin btnStyle {
+  width: 80px;
+  height: 40px;
+  border-radius: 10px;
+  border: none;
+  background: #974dcb;
+  &:hover {
+    background: #6937a1;
+  }
+}
+
+.MyInfo {
+  // display: flex;
+  margin-top: 100px;
+  background: white;
+  font-family: "Jua-Regular";
+  // border-radius: 25px;
+
+  // flex-direction: column;
+  
+  // align-items: left;
+  
+  width: 450px;
+
+  .MyInfoHeader {
+    // justify-content: center;
+    // float: left;
+
+    .Top {
+      height: 60px;
+
+      .GoBackButton {
+        margin: 10px;
+        float: left;
+        @include btnStyle()
+      }
+  
+      .MyInfoTitle {
+        // float: left;
+        display: flex;
+        height: 60px;
+        justify-content: center;
+        align-items: center;
+
+        font-size: 30px;
+      }
+    }
+    
+    .MyInfoHeaderDisplay {
+      display: flex;
+      background-color: yellow;
+      height: 100px;
+      align-items: center;
+      justify-content: end;
+
+      .LogoutButton {
+        margin: 10px;
+        
+        @include btnStyle()
+      }
+    }
+  }
+
+  .MyInfoTabs {
+    // display: flex;
+    // align-items: center;
+    // justify-content: center;
+    // overflow: hidden;
+
+    width: 80%;
+    height: auto;
+    min-height: 400px;
+    background: #053742;
+    margin: 3.5rem auto 1.5rem;
+    padding: 2rem 1rem;
+    color: #E8F0F2;
+    border-radius: 2rem;
+    @media (max-width: 769px) {
+      padding: 2rem 0;
+    }
+
+    //Tab 고르는 상단 바
+    .TabNav {
+      width: 80%;
+      margin: 0 auto 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      border: 1px solid #39A2DB;
+      border-radius: 2rem;
+      @media (max-width: 768px) {
+        width: 90%;
+      }
+
+      li {
+        width: 33%;
+      padding: 1rem;
+      list-style: none;
+      text-align: center;
+      cursor: pointer;
+      transition: all 0.7s;
+      border-bottom-left-radius: 2rem;
+      border-top-left-radius: 2rem;
+
+        &:nth-child(3) {
+          border-radius: 0;
+          border-bottom-right-radius: 2rem;
+          border-top-right-radius: 2rem;
+        }
+
+        &:hover {
+          background: rgba(50, 224, 196, 0.15);
+        }
+
+        .active {
+          background: #39A2DB;
+        }
+      }
+
+    }
+    
+    // 각 tab 컴포넌트 내부의 p태그 꾸미는 css
+    .FirstTab p,
+    .SecondTab p,
+    .ThirdTab p {
+    font-size: 2rem;
+    text-align: center;
+    }
+      
+
+  }
+    
+}
+
+
+
+
+
+

--- a/src/pages/MyInfo.tsx
+++ b/src/pages/MyInfo.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import "./MyInfo.scss";
+import MyInfoHeader from "../components/MyInfo/MyInfoHeader";
+import MyInfoTabs from "../components/MyInfo/MyInfoTabs";
+
+const MyInfo = () => {
+    return (
+      <div className="MyInfo">
+        <MyInfoHeader />
+        <MyInfoTabs />
+      </div>
+    );
+  };
+  
+export default MyInfo;


### PR DESCRIPTION

![Cap 2021-11-12 21-23-55-805](https://user-images.githubusercontent.com/85431296/141466695-2b5630c9-ac8e-46e1-a1ab-382367b011d5.png)

![Cap 2021-11-12 21-25-03-983](https://user-images.githubusercontent.com/85431296/141466830-f628fdb8-6f70-4aae-968e-b600a5f1af1c.png)

1. 요약
텐텐 내정보 창을 참고하여 유사하게 레이아웃 잡은 프로토 타입입니다. 
레이아웃을 확인하기위해 임의의 배경색들을 사용했습니다.

탭 기능이 포함되어있습니다. 통계, 캐릭터 선택, 칭호를 클릭할 경우 아래에 출력되는 내용이 변경됩니다. 


2. 코멘트
css 정돈이 필요합니다. 
플레이어 이름, 아이콘, 칭호가 뜨는 부분이 구현되지 않았습니다. 
내 정보 수정 페이지가 추가로 필요합니다.


